### PR TITLE
Add tote image gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Images
+
+Uploaded tote images are stored in the `tote-images` storage bucket on Supabase.
+Images are organized under a user id folder and referenced in the `tote_images`
+table which links each image to a specific tote.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/src/components/ToteDetails.tsx
+++ b/src/components/ToteDetails.tsx
@@ -4,6 +4,7 @@ import { InlineEdit } from "./InlineEdit";
 import { ArrowLeft } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { ToteQRCode } from "./ToteQRCode";
+import { ToteImageGallery } from "./ToteImageGallery";
 
 interface ToteDetailsProps {
   tote?: Partial<Tote> | null;
@@ -64,11 +65,7 @@ export function ToteDetails({ tote, onUpdateTote }: ToteDetailsProps) {
                 maxLength={500}
               />
 
-              {/* Placeholder for items within the tote if applicable */}
-              {/* <div className="mt-6">
-                <h2 className="text-2xl font-semibold">Items in this Tote</h2>
-                 You can map through tote.items or similar here if that data exists 
-              </div> */}
+              {tote.id && <ToteImageGallery toteId={tote.id} />}
             </div>
 
             {/* Sidebar - Right column (1/4 width on large screens) */}

--- a/src/components/ToteImageGallery.tsx
+++ b/src/components/ToteImageGallery.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import supabase from "../database/supabase";
+import { getToteImages, uploadToteImages, ToteImage } from "../database/queries";
+
+interface Props {
+  toteId: string;
+}
+
+export function ToteImageGallery({ toteId }: Props) {
+  const [images, setImages] = useState<ToteImage[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+  const [zoomSrc, setZoomSrc] = useState<string | null>(null);
+
+  useEffect(() => {
+    getToteImages(toteId)
+      .then((imgs) => setImages(imgs || []))
+      .catch((e) => console.error(e));
+  }, [toteId]);
+
+  const handleFileChange = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const files = Array.from(e.target.files || []);
+    if (!files.length) return;
+    setIsUploading(true);
+    try {
+      const uploaded = await uploadToteImages(toteId, files);
+      setImages((prev) => [...prev, ...uploaded]);
+      e.target.value = "";
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const getUrl = (path: string) => {
+    return supabase.storage.from("tote-images").getPublicUrl(path).data.publicUrl;
+  };
+
+  return (
+    <div className="mt-6">
+      <div className="mb-4 flex items-center gap-2">
+        <label className="btn btn-primary btn-sm">
+          Upload Images
+          <input
+            type="file"
+            multiple
+            className="hidden"
+            onChange={handleFileChange}
+            disabled={isUploading}
+          />
+        </label>
+        {isUploading && (
+          <span className="loading loading-sm loading-spinner"></span>
+        )}
+      </div>
+      {images.length > 0 && (
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+          {images.map((img) => {
+            const url = getUrl(img.file_path);
+            return (
+              <img
+                key={img.id}
+                src={url}
+                onClick={() => setZoomSrc(url)}
+                className="aspect-square w-full cursor-pointer rounded-box object-cover"
+              />
+            );
+          })}
+        </div>
+      )}
+      {zoomSrc && (
+        <dialog
+          className="modal modal-open"
+          onClick={() => setZoomSrc(null)}
+        >
+          <div
+            className="modal-box max-w-5xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <img src={zoomSrc} className="w-full" />
+          </div>
+        </dialog>
+      )}
+    </div>
+  );
+}

--- a/src/database/database.types.ts
+++ b/src/database/database.types.ts
@@ -61,6 +61,31 @@ export type Database = {
         }
         Relationships: []
       }
+      ,
+      tote_images: {
+        Row: {
+          created_on: string
+          id: string
+          file_path: string
+          tote_id: string
+          user_id: string
+        }
+        Insert: {
+          created_on?: string
+          id?: string
+          file_path: string
+          tote_id: string
+          user_id: string
+        }
+        Update: {
+          created_on?: string
+          id?: string
+          file_path?: string
+          tote_id?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never

--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -80,6 +80,17 @@ export async function getToteImages(toteId: string) {
   return data;
 }
 
+export async function getToteImageUrl(filePath: string, expiresIn = 60 * 60) {
+  const { data, error } = await supabase.storage
+    .from("tote-images")
+    .createSignedUrl(filePath, expiresIn);
+  if (error) {
+    console.error("Error generating image URL:", error);
+    throw error;
+  }
+  return data?.signedUrl || "";
+}
+
 export async function uploadToteImages(toteId: string, files: File[]) {
   const {
     data: { session },


### PR DESCRIPTION
## Summary
- add docs for tote image storage
- add `tote_images` table to Supabase types
- support listing and uploading images
- show gallery in tote details with zoomable modal

## Testing
- `npm run lint` *(fails: 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68463cfb8c688327ae29b912ba2faf8b