### PR TITLE
Fix tote details update handlers

### DIFF
--- a/src/components/ToteDetails.tsx
+++ b/src/components/ToteDetails.tsx
@@ -18,15 +18,12 @@ export function ToteDetails({ tote, onUpdateTote }: ToteDetailsProps) {
 
   const handleUpdateTitle = async (newTitle: string) => {
     if (!tote.id) return;
-    await onUpdateTote?.(tote.id, { ...tote, tote_name: newTitle });
+    await onUpdateTote?.(tote.id, { tote_name: newTitle });
   };
 
   const handleUpdateDescription = async (newDescription: string) => {
     if (!tote.id) return;
-    await onUpdateTote?.(tote.id, {
-      ...tote,
-      tote_description: newDescription,
-    });
+    await onUpdateTote?.(tote.id, { tote_description: newDescription });
   };
 
   return (


### PR DESCRIPTION
## Summary
- adjust title/description update handlers to send only changed fields

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846424d53bc83279e1c609f6c4df741